### PR TITLE
feat: support altitude-dependent drag

### DIFF
--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -102,6 +102,13 @@ class _RocketPlots:
         -------
         None
         """
+        if (
+            self.rocket.power_on_drag.get_domain_dim() > 1
+            or self.rocket.power_off_drag.get_domain_dim() > 1
+        ):
+            self.rocket.power_on_drag.plot()
+            self.rocket.power_off_drag.plot()
+            return
 
         try:
             x_power_drag_on = self.rocket.power_on_drag.x_array

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -336,19 +336,24 @@ class Rocket:
         )
 
         # Define aerodynamic drag coefficients
-        self.power_off_drag = Function(
-            power_off_drag,
-            "Mach Number",
-            "Drag Coefficient with Power Off",
-            "linear",
-            "constant",
+        def _setup_drag_function(source, output_name):
+            drag = Function(
+                source,
+                interpolation="linear",
+                extrapolation="constant",
+            )
+            drag.set_outputs(output_name)
+            if drag.get_domain_dim() == 1:
+                drag.set_inputs("Mach Number")
+            else:
+                drag.set_inputs(["Mach Number", "Altitude (m)"])
+            return drag
+
+        self.power_off_drag = _setup_drag_function(
+            power_off_drag, "Drag Coefficient with Power Off"
         )
-        self.power_on_drag = Function(
-            power_on_drag,
-            "Mach Number",
-            "Drag Coefficient with Power On",
-            "linear",
-            "constant",
+        self.power_on_drag = _setup_drag_function(
+            power_on_drag, "Drag Coefficient with Power On"
         )
 
         # Create a, possibly, temporary empty motor

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1349,7 +1349,12 @@ class Flight:
             + (vz) ** 2
         ) ** 0.5
         free_stream_mach = free_stream_speed / self.env.speed_of_sound.get_value_opt(z)
-        drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+        if self.rocket.power_on_drag.get_domain_dim() == 1:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+        else:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                free_stream_mach, z
+            )
 
         # Calculate Forces
         pressure = self.env.pressure.get_value_opt(z)
@@ -1520,9 +1525,23 @@ class Flight:
         # Determine aerodynamics forces
         # Determine Drag Force
         if t < self.rocket.motor.burn_out_time:
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach
+                )
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         else:
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach
+                )
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         rho = self.env.density.get_value_opt(z)
         R3 = -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
@@ -1797,10 +1816,24 @@ class Flight:
                 + self.rocket.motor.pressure_thrust(pressure),
                 0,
             )
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach
+                )
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         else:
             net_thrust = 0
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach
+                )
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         R3 += -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
             if air_brakes.deployment_level > 0:

--- a/tests/unit/test_drag_altitude.py
+++ b/tests/unit/test_drag_altitude.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from rocketpy import Rocket, Flight
+
+
+def test_drag_curve_with_altitude_array():
+    data = np.array(
+        [
+            [0.0, 0.0, 0.3],
+            [0.0, 1000.0, 0.2],
+            [1.0, 0.0, 0.4],
+            [1.0, 1000.0, 0.3],
+        ]
+    )
+    rocket = Rocket(
+        radius=0.05,
+        mass=1.0,
+        inertia=(1, 1, 1),
+        power_off_drag=data,
+        power_on_drag=data,
+        center_of_mass_without_motor=0,
+        coordinate_system_orientation="tail_to_nose",
+    )
+    assert rocket.power_off_drag.get_domain_dim() == 2
+    assert rocket.power_off_drag.get_value_opt(1.0, 1000.0) == pytest.approx(0.3)
+
+
+def test_u_dot_uses_altitude(example_plain_env):
+    calls = {}
+
+    def drag_func(mach, alt):
+        calls["mach"] = mach
+        calls["alt"] = alt
+        return 0.5
+
+    rocket = Rocket(
+        radius=0.05,
+        mass=1.0,
+        inertia=(1, 1, 1),
+        power_off_drag=drag_func,
+        power_on_drag=drag_func,
+        center_of_mass_without_motor=0,
+        coordinate_system_orientation="tail_to_nose",
+    )
+
+    flight = Flight(
+        rocket=rocket,
+        environment=example_plain_env,
+        rail_length=1,
+        max_time=0.1,
+        time_overshoot=False,
+    )
+
+    state = [0, 0, 1000.0, 100.0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+    flight.u_dot(0, state)
+    expected_mach = 100.0 / example_plain_env.speed_of_sound.get_value_opt(1000.0)
+    assert calls["alt"] == 1000.0
+    assert calls["mach"] == pytest.approx(expected_mach)
+


### PR DESCRIPTION
## Summary
- allow drag coefficient curves to accept altitude as a second input
- compute drag using altitude-aware coefficients during flight
- display 3D drag coefficient surfaces when altitude data is provided

## Testing
- `pytest tests/unit/test_drag_altitude.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688de8f98eb4832ea5bcd77efab3c40b