### PR TITLE
Validate drag curve column count

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -253,6 +253,20 @@ class Function:  # pylint: disable=too-many-public-methods
             self._source_type = SourceType.ARRAY
             # Evaluate dimension
             self.__dom_dim__ = source.shape[1] - 1
+            if self.__dom_dim__ > 2:
+                inputs = self.__inputs__
+                if isinstance(inputs, str) or not isinstance(inputs, Iterable):
+                    inputs_list = [inputs]
+                else:
+                    inputs_list = list(inputs)
+                if any(
+                    inp is not None and "mach" in str(inp).lower() for inp in inputs_list
+                ):
+                    raise ValueError(
+                        "Drag curve data must contain exactly two input columns: Mach and altitude. "
+                        f"Detected {self.__dom_dim__} input columns. Ensure the CSV layout is 'Mach, Altitude, Drag Coefficient'."
+                    )
+
             self._domain = source[:, :-1]
             self._image = source[:, -1]
 
@@ -369,22 +383,6 @@ class Function:  # pylint: disable=too-many-public-methods
         """Defines interpolation function used by the Function. Each
         interpolation method has its own function`.
         The function is stored in the attribute _interpolation_func."""
-        # If a drag curve is provided with more than two input columns, raise an
-        # informative error to guide the user. Drag curves are expected to have
-        # Mach and altitude as inputs only. Extra columns usually indicate a
-        # misformatted CSV.
-        if self.__dom_dim__ > 2:
-            inputs = self.__inputs__
-            if isinstance(inputs, str) or not isinstance(inputs, Iterable):
-                inputs_list = [inputs]
-            else:
-                inputs_list = list(inputs)
-            if any(inp is not None and "Mach" in str(inp) for inp in inputs_list):
-                raise ValueError(
-                    "Drag curve data must contain exactly two input columns: Mach and altitude. "
-                    f"Detected {self.__dom_dim__} input columns. Ensure the CSV layout is 'Mach, Altitude, Drag Coefficient'."
-                )
-
         interpolation = INTERPOLATION_TYPES[self.__interpolation__]
         if interpolation == 0:  # linear
             if self.__dom_dim__ == 1:

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -369,6 +369,22 @@ class Function:  # pylint: disable=too-many-public-methods
         """Defines interpolation function used by the Function. Each
         interpolation method has its own function`.
         The function is stored in the attribute _interpolation_func."""
+        # If a drag curve is provided with more than two input columns, raise an
+        # informative error to guide the user. Drag curves are expected to have
+        # Mach and altitude as inputs only. Extra columns usually indicate a
+        # misformatted CSV.
+        if self.__dom_dim__ > 2:
+            inputs = self.__inputs__
+            if isinstance(inputs, str) or not isinstance(inputs, Iterable):
+                inputs_list = [inputs]
+            else:
+                inputs_list = list(inputs)
+            if any(inp is not None and "Mach" in str(inp) for inp in inputs_list):
+                raise ValueError(
+                    "Drag curve data must contain exactly two input columns: Mach and altitude. "
+                    f"Detected {self.__dom_dim__} input columns. Ensure the CSV layout is 'Mach, Altitude, Drag Coefficient'."
+                )
+
         interpolation = INTERPOLATION_TYPES[self.__interpolation__]
         if interpolation == 0:  # linear
             if self.__dom_dim__ == 1:

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -1199,3 +1199,22 @@ def test_short_time_fft(
         else:
             assert np.all(frequencies >= -sampling_frequency / 2)
             assert np.all(frequencies <= sampling_frequency / 2)
+
+
+def test_drag_curve_csv_with_extra_columns(tmp_path):
+    """Ensure drag curve CSV files with more than two input columns raise an error."""
+
+    csv_file = tmp_path / "bad_drag_curve.csv"
+    csv_file.write_text(
+        "Mach,Altitude,Extra,Cd\n"
+        "0,0,0,0.1\n"
+        "0.5,1000,0.2,0.2\n"
+        "1.0,2000,0.3,0.3\n"
+        "1.5,3000,0.4,0.4\n"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Drag curve data must contain exactly two input columns: Mach and altitude",
+    ):
+        Function(str(csv_file), inputs=["Mach", "Altitude"], outputs="Drag Coefficient")

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -1217,4 +1217,4 @@ def test_drag_curve_csv_with_extra_columns(tmp_path):
         ValueError,
         match="Drag curve data must contain exactly two input columns: Mach and altitude",
     ):
-        Function(str(csv_file), inputs=["Mach", "Altitude"], outputs="Drag Coefficient")
+        Function(str(csv_file))


### PR DESCRIPTION
## Summary
- ensure drag curve data has only Mach and altitude input columns
- add unit test for malformed drag CSV input

## Testing
- `pytest tests/unit/test_function.py::test_drag_curve_csv_with_extra_columns -q`
- `pytest tests/unit/test_function.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1d4197c8832e8143062f9b61e039