### PR TITLE
Handle extra columns in Function source

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -252,6 +252,20 @@ class Function:  # pylint: disable=too-many-public-methods
         else:
             self._source_type = SourceType.ARRAY
             # Evaluate dimension
+            if (
+                isinstance(self.__inputs__, str)
+                or (
+                    isinstance(self.__inputs__, (list, tuple))
+                    and len(self.__inputs__) == 1
+                )
+            ) and source.shape[1] > 2:
+                # If a single input name is provided but the source has
+                # extra columns, keep only the first and last columns so
+                # the resulting Function behaves as 1-D. This avoids raising
+                # errors when users supply data files with auxiliary columns
+                # that should be ignored.
+                source = source[:, [0, -1]]
+
             self.__dom_dim__ = source.shape[1] - 1
             self._domain = source[:, :-1]
             self._image = source[:, -1]

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -1199,3 +1199,21 @@ def test_short_time_fft(
         else:
             assert np.all(frequencies >= -sampling_frequency / 2)
             assert np.all(frequencies <= sampling_frequency / 2)
+
+
+def test_function_single_input_with_extra_columns():
+    """Ensure Function handles extra data columns when only one input name is provided."""
+
+    data = np.array(
+        [
+            [0.0, 10.0, 0.0],
+            [0.5, 15.0, 0.5],
+            [1.0, 20.0, 1.0],
+        ]
+    )
+
+    func = Function(data, "x", "y")
+
+    assert np.isclose(func(0.0), 0.0)
+    assert np.isclose(func(1.0), 1.0)
+    assert func.get_domain_dim() == 1


### PR DESCRIPTION
## Summary
- allow `Function` to ignore auxiliary columns when only one input is specified
- add regression test ensuring extra columns are handled correctly

## Testing
- `pytest tests/unit/test_function.py::test_function_single_input_with_extra_columns -q`
- `pytest tests/unit/test_function.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e236ed084832e8c93e64654ea5ed6