### PR TITLE
Add altitude-aware drag curves and 3D plotting

### DIFF
--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.patches import Patch
 
 from rocketpy.motors import EmptyMotor, HybridMotor, LiquidMotor, SolidMotor
 from rocketpy.rocket.aero_surface import Fins, NoseCone, Tail
@@ -103,36 +104,87 @@ class _RocketPlots:
         None
         """
 
-        try:
-            x_power_drag_on = self.rocket.power_on_drag.x_array
-            y_power_drag_on = self.rocket.power_on_drag.y_array
-        except AttributeError:
-            x_power_drag_on = np.linspace(0, 2, 50)
-            y_power_drag_on = np.array(
-                [self.rocket.power_on_drag.source(x) for x in x_power_drag_on]
-            )
-        try:
-            x_power_drag_off = self.rocket.power_off_drag.x_array
-            y_power_drag_off = self.rocket.power_off_drag.y_array
-        except AttributeError:
-            x_power_drag_off = np.linspace(0, 2, 50)
-            y_power_drag_off = np.array(
-                [self.rocket.power_off_drag.source(x) for x in x_power_drag_off]
+        if (
+            self.rocket.power_on_drag.get_domain_dim() == 1
+            and self.rocket.power_off_drag.get_domain_dim() == 1
+        ):
+            try:
+                x_power_drag_on = self.rocket.power_on_drag.x_array
+                y_power_drag_on = self.rocket.power_on_drag.y_array
+            except AttributeError:
+                x_power_drag_on = np.linspace(0, 2, 50)
+                y_power_drag_on = np.array(
+                    [self.rocket.power_on_drag.source(x) for x in x_power_drag_on]
+                )
+            try:
+                x_power_drag_off = self.rocket.power_off_drag.x_array
+                y_power_drag_off = self.rocket.power_off_drag.y_array
+            except AttributeError:
+                x_power_drag_off = np.linspace(0, 2, 50)
+                y_power_drag_off = np.array(
+                    [self.rocket.power_off_drag.source(x) for x in x_power_drag_off]
+                )
+
+            _, ax = plt.subplots()
+            ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")
+            ax.plot(
+                x_power_drag_off, y_power_drag_off, label="Power off Drag", linestyle="--"
             )
 
-        _, ax = plt.subplots()
-        ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")
-        ax.plot(
-            x_power_drag_off, y_power_drag_off, label="Power off Drag", linestyle="--"
-        )
+            ax.set_title("Drag Curves")
+            ax.set_ylabel("Drag Coefficient")
+            ax.set_xlabel("Mach")
+            ax.axvspan(0.8, 1.2, alpha=0.3, color="gray", label="Transonic Region")
+            ax.legend(loc="best", shadow=True)
+            plt.grid(True)
+            show_or_save_plot(filename)
+        else:
+            # 3D surface plot for drag coefficient vs Mach vs Altitude
+            x_on = self.rocket.power_on_drag.x_array
+            y_on = self.rocket.power_on_drag.y_array
+            x_off = self.rocket.power_off_drag.x_array
+            y_off = self.rocket.power_off_drag.y_array
 
-        ax.set_title("Drag Curves")
-        ax.set_ylabel("Drag Coefficient")
-        ax.set_xlabel("Mach")
-        ax.axvspan(0.8, 1.2, alpha=0.3, color="gray", label="Transonic Region")
-        ax.legend(loc="best", shadow=True)
-        plt.grid(True)
-        show_or_save_plot(filename)
+            x_min = min(x_on.min(), x_off.min())
+            x_max = max(x_on.max(), x_off.max())
+            y_min = min(y_on.min(), y_off.min())
+            y_max = max(y_on.max(), y_off.max())
+
+            mach = np.linspace(x_min, x_max, 30)
+            altitude = np.linspace(y_min, y_max, 30)
+            mesh_mach, mesh_alt = np.meshgrid(mach, altitude)
+
+            z_on = np.array(
+                self.rocket.power_on_drag.get_value(
+                    mesh_mach.flatten(), mesh_alt.flatten()
+                )
+            ).reshape(mesh_mach.shape)
+            z_off = np.array(
+                self.rocket.power_off_drag.get_value(
+                    mesh_mach.flatten(), mesh_alt.flatten()
+                )
+            ).reshape(mesh_mach.shape)
+
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection="3d")
+            surf_on = ax.plot_surface(
+                mesh_mach, mesh_alt, z_on, cmap="viridis", alpha=0.7
+            )
+            surf_off = ax.plot_surface(
+                mesh_mach, mesh_alt, z_off, cmap="plasma", alpha=0.7
+            )
+
+            ax.set_title("Drag Curves")
+            ax.set_xlabel("Mach")
+            ax.set_ylabel("Altitude (m)")
+            ax.set_zlabel("Drag Coefficient")
+
+            legend_elements = [
+                Patch(facecolor=plt.cm.viridis(0.6), label="Power on Drag"),
+                Patch(facecolor=plt.cm.plasma(0.6), label="Power off Drag"),
+            ]
+            ax.legend(handles=legend_elements, loc="best", shadow=True)
+            show_or_save_plot(filename)
 
     def thrust_to_weight(self):
         """

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -338,18 +338,29 @@ class Rocket:
         # Define aerodynamic drag coefficients
         self.power_off_drag = Function(
             power_off_drag,
-            "Mach Number",
-            "Drag Coefficient with Power Off",
-            "linear",
-            "constant",
+            inputs=None,
+            outputs="Drag Coefficient with Power Off",
+            interpolation="linear",
+            extrapolation="constant",
         )
         self.power_on_drag = Function(
             power_on_drag,
-            "Mach Number",
-            "Drag Coefficient with Power On",
-            "linear",
-            "constant",
+            inputs=None,
+            outputs="Drag Coefficient with Power On",
+            interpolation="linear",
+            extrapolation="constant",
         )
+
+        # Set drag curve input labels based on data dimensionality
+        if self.power_off_drag.get_domain_dim() == 1:
+            self.power_off_drag.set_inputs("Mach Number")
+        else:
+            self.power_off_drag.set_inputs(["Mach Number", "Altitude (m)"])
+
+        if self.power_on_drag.get_domain_dim() == 1:
+            self.power_on_drag.set_inputs("Mach Number")
+        else:
+            self.power_on_drag.set_inputs(["Mach Number", "Altitude (m)"])
 
         # Create a, possibly, temporary empty motor
         # self.motors = Components()  # currently unused, only 1 motor is supported

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1349,7 +1349,12 @@ class Flight:
             + (vz) ** 2
         ) ** 0.5
         free_stream_mach = free_stream_speed / self.env.speed_of_sound.get_value_opt(z)
-        drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+        if self.rocket.power_on_drag.get_domain_dim() == 1:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+        else:
+            drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                free_stream_mach, z
+            )
 
         # Calculate Forces
         pressure = self.env.pressure.get_value_opt(z)
@@ -1520,9 +1525,19 @@ class Flight:
         # Determine aerodynamics forces
         # Determine Drag Force
         if t < self.rocket.motor.burn_out_time:
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         else:
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         rho = self.env.density.get_value_opt(z)
         R3 = -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
@@ -1797,10 +1812,20 @@ class Flight:
                 + self.rocket.motor.pressure_thrust(pressure),
                 0,
             )
-            drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_on_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
+            else:
+                drag_coeff = self.rocket.power_on_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         else:
             net_thrust = 0
-            drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            if self.rocket.power_off_drag.get_domain_dim() == 1:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)
+            else:
+                drag_coeff = self.rocket.power_off_drag.get_value_opt(
+                    free_stream_mach, z
+                )
         R3 += -0.5 * rho * (free_stream_speed**2) * self.rocket.area * drag_coeff
         for air_brakes in self.rocket.air_brakes:
             if air_brakes.deployment_level > 0:


### PR DESCRIPTION
## Summary
- allow rocket drag curves to use altitude and label inputs based on dimensionality
- compute drag coefficient with altitude data during simulation
- plot 3D drag coefficient surfaces over Mach and altitude

## Testing
- `pytest` *(fails: tests/integration/test_environment.py::test_windy_atmosphere[ECMWF], tests/integration/test_environment.py::test_windy_atmosphere[GFS], tests/integration/test_environment.py::test_windy_atmosphere[ICON])*

------
https://chatgpt.com/codex/tasks/task_e_688e28ffb828832e9ea281f7e2996264