### PR TITLE
Add simple test method to Rocket

### DIFF
--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -2004,3 +2004,7 @@ class Rocket:
             )
 
         return rocket
+
+    def test(self):
+        """Prints a simple test message."""
+        print("Test")

--- a/tests/unit/test_rocket.py
+++ b/tests/unit/test_rocket.py
@@ -655,3 +655,9 @@ def test_coordinate_system_orientation(
     static_margin_nose_to_tail = rocket_nose_to_tail.static_margin
 
     assert np.array_equal(static_margin_tail_to_nose, static_margin_nose_to_tail)
+
+
+def test_test_method_prints_Test(capsys, calisto):
+    calisto.test()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Test"


### PR DESCRIPTION
## Summary
- add `test` method to `Rocket`
- exercise method in unit tests

## Testing
- `pytest tests/unit/test_rocket.py::test_test_method_prints_Test -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2e57f184832e891c4a2f9267be8a